### PR TITLE
feat: 現在ログインしているアカウントのメールアドレスを表示

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -81,6 +81,7 @@ const Sidebar = () => {
         </ul>
       </div>
 
+      {user && <div className='mb-2 p-4 text-slate-100 text-lg font-medium'>{user.email}</div>}
       <div
         className='text-lg flex items-center justify-evenly mb-2 cursor-pointer p-4 text-slate-100 hover:bg-slate-700 duration-150'
         onClick={() => handleLogout()}


### PR DESCRIPTION
issue: 

概要

利便性向上のため、現在ログインしているアカウントのメールアドレスを表示する

動作確認

https://github.com/shunichfukui/chatgpt-chat/assets/68207981/4589dc13-8a11-4444-b270-4a910387cc4d

