### PR TITLE
fix: リロードのたびにログアウトしてしまっていたので修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,16 +3,8 @@
 import Sidebar from './components/Sidebar';
 import Chat from './components/Chat';
 import { useAppContext } from '@/context/AppContext';
-import { useRouter } from 'next/navigation';
 
 export default function Home() {
-  const { user } = useAppContext();
-  const router = useRouter();
-
-  if (!user) {
-    router.push('/auth/login');
-  }
-
   return (
     <div className='flex h-screen justify-center items-center'>
       <div className='h-full flex' style={{ width: '1280px' }}>


### PR DESCRIPTION
issue: 

概要
画面をリロードするたびにログアウトしてしまっていたので修正


動作確認
ログイン状態でホーム画面→リロード→ホーム画面　　問題なし
ログアウト状態でホーム画面→ログイン画面に遷移　　問題なし

https://github.com/shunichfukui/chatgpt-chat/assets/68207981/a5d9ca74-994f-47fc-9517-e36e9db0ba80

