### PR TITLE
fix: チャット周りのバグ回収

### DIFF
--- a/src/app/components/Chat.tsx
+++ b/src/app/components/Chat.tsx
@@ -59,6 +59,12 @@ const Chat = () => {
   const sendMessage = async () => {
     if (!inputMessage.trim()) return;
 
+    setIsLoading(true);
+
+    if (isLoading) {
+      return;
+    }
+
     const messageData = {
       text: inputMessage,
       sender: 'user',
@@ -71,23 +77,26 @@ const Chat = () => {
     await addDoc(messageCollectionRef, messageData);
 
     setInputMessage('');
-    setIsLoading(true);
 
-    //OpenAIからの返信
-    const gptResponse = await openai.chat.completions.create({
-      messages: [{ role: 'user', content: inputMessage }],
-      model: GPT_VERSION,
-    });
+    try {
+      //OpenAIからの返信
+      const gptResponse = await openai.chat.completions.create({
+        messages: [{ role: 'user', content: inputMessage }],
+        model: GPT_VERSION,
+      });
 
-    const botResponse = gptResponse.choices[0].message.content;
+      const botResponse = gptResponse.choices[0].message.content;
 
-    await addDoc(messageCollectionRef, {
-      text: botResponse,
-      sender: 'bot',
-      createdAt: serverTimestamp(),
-    });
-
-    setIsLoading(false);
+      await addDoc(messageCollectionRef, {
+        text: botResponse,
+        sender: 'bot',
+        createdAt: serverTimestamp(),
+      });
+    } catch (error) {
+      console.error('Error sending message to OpenAI:', error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (

--- a/src/app/components/Chat.tsx
+++ b/src/app/components/Chat.tsx
@@ -115,6 +115,7 @@ const Chat = () => {
           type='text'
           placeholder='Send a Message'
           onChange={(e) => setInputMessage(e.target.value)}
+          value={inputMessage}
           className='border-2 rounded w-full pr-10 focus:outline-none p-2'
           onKeyDown={(e) => {
             if (e.key === 'Enter') {


### PR DESCRIPTION
issue: 

概要
修正内容は以下二点

- メッセージ送信時にフォームの値が空になっていなかったので修正
- fix: enterKeyを二連で実行すると二つメッセージが送信できてしまっていたので修正

動作確認

https://github.com/shunichfukui/chatgpt-chat/assets/68207981/2c4f3a5a-5b2a-4543-8492-ab53486bf893


